### PR TITLE
feat: added MCP tool resource scanner - partial and full

### DIFF
--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/errors.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/errors.py
@@ -67,6 +67,20 @@ def handle_aws_api_error(e: Exception) -> Exception:
         return ServerError('Internal failure. The server failed to process the request.')
     elif 'ServiceUnavailable' in error_message or error_type == 'ServiceUnavailable':
         return ServerError('Service unavailable. The server failed to process the request.')
+    elif (
+        'ResourceScanInProgressException' in error_message
+        or error_type == 'ResourceScanInProgressException'
+    ):
+        return ClientError(
+            'Resource scan is already in progress. Please wait for the current scan to complete before starting a new one.'
+        )
+    elif (
+        'ResourceScanLimitExceededException' in error_message
+        or error_type == 'ResourceScanLimitExceededException'
+    ):
+        return ClientError(
+            'Resource scan limit exceeded. You have reached the maximum number of concurrent resource scans allowed.'
+        )
     else:
         # Generic error handling - we might shift to this for everything eventually since it gives more context to the LLM, will have to test
         return ClientError(f'An error occurred: {error_message}')
@@ -80,6 +94,17 @@ class ClientError(Exception):
         # Call the base class constructor with the parameters it needs
         super().__init__(message)
         self.type = 'client'
+        self.message = message
+
+
+class PromptUser(Exception):
+    """An error that indicates that the user needs to provide additional information or input."""
+
+    def __init__(self, message):
+        """Call super and set message."""
+        # Call the base class constructor with the parameters it needs
+        super().__init__(message)
+        self.type = 'prompt_user'
         self.message = message
 
 

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/stack_analysis/cloudformation_utils.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/stack_analysis/cloudformation_utils.py
@@ -115,7 +115,7 @@ class CloudFormationUtils:
         return response.get('TemplateBody', {})
 
     # Resource Scan API methods
-    def start_resource_scan(self) -> Optional[str]:
+    def start_resource_scan(self, resource_type: Optional[List] = None) -> str:
         """Start a new resource scan and return the scan ID.
 
         Returns:
@@ -123,10 +123,23 @@ class CloudFormationUtils:
         """
         try:
             logger.info('Starting resource scan...')
-            response = self.cfn_client.start_resource_scan()
-            self.resource_scan_id = response['ResourceScanId']
+            logger.info(f'Received resource_type: {resource_type} (type: {type(resource_type)})')
+
+            if resource_type and len(resource_type) > 0:
+                logger.info(f'Starting resource scan with filters: {resource_type}')
+                response = self.cfn_client.start_resource_scan(
+                    ScanFilters=[{'Types': resource_type}]
+                )
+            else:
+                response = self.cfn_client.start_resource_scan()
+
+            scan_id = response['ResourceScanId']
+            if not scan_id:
+                raise ClientError('Resource scan ID not returned by AWS API')
+
+            self.resource_scan_id = scan_id
             logger.info(f'Resource scan started with ID: {self.resource_scan_id}')
-            return self.resource_scan_id
+            return scan_id
         except Exception as e:
             logger.error(f'Error starting resource scan: {str(e)}')
             raise handle_aws_api_error(e)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #[issue-number-if-applicable]

## Summary

### Changes

Added comprehensive resource scanning capabilities to the CloudFormation MCP server, enabling both partial and full AWS account resource scans. This enhancement includes:

- Implementation of `start_resource_scan` tool for initiating resource scans with optional filtering by resource types
- Support for full account scans (all resource types) and targeted scans (specific resource types like S3 buckets, EC2 instances, RDS databases)
- Fixed type annotation issue in `start_resource_scan` method to ensure proper return type handling
- Enhanced error handling and validation for resource scan operations, along with PromptUser Exception handling

### User experience
Users can now:
- Initiate comprehensive scans of their entire AWS account and retrieve the resource scan ID
- Perform targeted scans for specific resource types  or a whole list of them(e.g., only S3 buckets and EC2 instances)
- Get scan IDs for tracking long-running scan operations

Example usage:
- Full account scan: `start_resource_scan(resource_type=[])`
- Targeted scan: `start_resource_scan(resource_type=["AWS::S3::Bucket", "AWS::EC2::Instance", "AWS::RDS::DBInstance"])`

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
