### PR TITLE
feat: Added resource scanner MCP tool - partial and full

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -143,7 +143,7 @@ jobs:
               fi;
             ) || echo "good $line"
           done < .venv/FILES;
-          uv tool run --from cyclonedx-bom cyclonedx-py environment $VIRTUAL_ENV --PEP-639 --gather-license-texts --pyproject pyproject.toml --mc-type library --output-format JSON > sbom.json
+          uv tool run --from cyclonedx-bom cyclonedx-py environment $VIRTUAL_ENV --gather-license-texts --pyproject pyproject.toml --mc-type library --output-format JSON > sbom.json
       - name: Display SBOM
         working-directory: src/${{ matrix.package }}
         run: |

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/errors.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/errors.py
@@ -67,6 +67,20 @@ def handle_aws_api_error(e: Exception) -> Exception:
         return ServerError('Internal failure. The server failed to process the request.')
     elif 'ServiceUnavailable' in error_message or error_type == 'ServiceUnavailable':
         return ServerError('Service unavailable. The server failed to process the request.')
+    elif (
+        'ResourceScanInProgressException' in error_message
+        or error_type == 'ResourceScanInProgressException'
+    ):
+        return ClientError(
+            'Resource scan is already in progress. Please wait for the current scan to complete before starting a new one.'
+        )
+    elif (
+        'ResourceScanLimitExceededException' in error_message
+        or error_type == 'ResourceScanLimitExceededException'
+    ):
+        return ClientError(
+            'Resource scan limit exceeded. You have reached the maximum number of concurrent resource scans allowed.'
+        )
     else:
         # Generic error handling - we might shift to this for everything eventually since it gives more context to the LLM, will have to test
         return ClientError(f'An error occurred: {error_message}')
@@ -80,6 +94,17 @@ class ClientError(Exception):
         # Call the base class constructor with the parameters it needs
         super().__init__(message)
         self.type = 'client'
+        self.message = message
+
+
+class PromptUser(Exception):
+    """An error that indicates that the user needs to provide additional information or input."""
+
+    def __init__(self, message):
+        """Call super and set message."""
+        # Call the base class constructor with the parameters it needs
+        super().__init__(message)
+        self.type = 'prompt_user'
         self.message = message
 
 

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
@@ -435,8 +435,8 @@ async def start_resource_scan(
     """Start a resource scan for a specific AWS resource type or the entire account.
 
     Parameters:
-        resource_type: The AWS resource type to scan (e.g., "AWS::S3::Bucket" or a list of resource types)
-                      Leave empty or None to scan the entire account
+        resource_type: The AWS resource type to scan (e.g., "AWS::S3::Bucket", "AWS::EC2::*", or a list of resource types)
+        Provide an empty list [] to scan the entire account
         region: AWS region to use (e.g., "us-east-1", "us-west-2")
 
     Returns:

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
@@ -424,18 +424,18 @@ async def create_template(
 
 @mcp.tool()
 async def start_resource_scan(
-    resource_type: list | None = Field(
+    resource_types: list | None = Field(
         default=None,
-        description='The AWS resource type to scan (e.g., "AWS::S3::Bucket", "AWS::RDS::DBInstance")',
+        description='The AWS resource types to scan (e.g., "AWS::S3::Bucket", "AWS::RDS::DBInstance")',
     ),
     region: str | None = Field(
         description='The AWS region that the operation should be performed in', default=None
     ),
 ) -> dict:
-    """Start a resource scan for a specific AWS resource type or the entire account.
+    """Start a resource scan for a specific AWS resource types or the entire account.
 
     Parameters:
-        resource_type: The AWS resource type to scan (e.g., "AWS::S3::Bucket", "AWS::EC2::*", or a list of resource types)
+        resource_type: The AWS resource types to scan (e.g., "AWS::S3::Bucket", "AWS::EC2::*", or a list of resource types)
         Provide an empty list [] to scan the entire account
         region: AWS region to use (e.g., "us-east-1", "us-west-2")
 
@@ -446,7 +446,7 @@ async def start_resource_scan(
         }
     """
     # Prompt user for input if no resource type is provided
-    if resource_type is None:
+    if resource_types is None:
         common_resource_types = [
             'AWS::S3::Bucket',
             'AWS::EC2::Instance',
@@ -473,7 +473,7 @@ async def start_resource_scan(
         raise handle_aws_api_error(e)
 
     try:
-        scan_id = cfn_utils.start_resource_scan(resource_type)
+        scan_id = cfn_utils.start_resource_scan(resource_types)
         return {
             'scan_id': scan_id,
         }

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/stack_analysis/cloudformation_utils.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/stack_analysis/cloudformation_utils.py
@@ -115,7 +115,7 @@ class CloudFormationUtils:
         return response.get('TemplateBody', {})
 
     # Resource Scan API methods
-    def start_resource_scan(self) -> Optional[str]:
+    def start_resource_scan(self, resource_type: Optional[List] = None) -> str:
         """Start a new resource scan and return the scan ID.
 
         Returns:
@@ -123,10 +123,23 @@ class CloudFormationUtils:
         """
         try:
             logger.info('Starting resource scan...')
-            response = self.cfn_client.start_resource_scan()
-            self.resource_scan_id = response['ResourceScanId']
+            logger.info(f'Received resource_type: {resource_type} (type: {type(resource_type)})')
+
+            if resource_type and len(resource_type) > 0:
+                logger.info(f'Starting resource scan with filters: {resource_type}')
+                response = self.cfn_client.start_resource_scan(
+                    ScanFilters=[{'Types': resource_type}]
+                )
+            else:
+                response = self.cfn_client.start_resource_scan()
+
+            scan_id = response['ResourceScanId']
+            if not scan_id:
+                raise ClientError('Resource scan ID not returned by AWS API')
+
+            self.resource_scan_id = scan_id
             logger.info(f'Resource scan started with ID: {self.resource_scan_id}')
-            return self.resource_scan_id
+            return scan_id
         except Exception as e:
             logger.error(f'Error starting resource scan: {str(e)}')
             raise handle_aws_api_error(e)

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/stack_analysis/cloudformation_utils.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/stack_analysis/cloudformation_utils.py
@@ -14,7 +14,7 @@
 
 import logging
 from awslabs.cfn_mcp_server.aws_client import get_aws_client
-from awslabs.cfn_mcp_server.errors import ClientError, handle_aws_api_error
+from awslabs.cfn_mcp_server.errors import ClientError, ServerError, handle_aws_api_error
 from typing import Any, Dict, List, Optional
 
 
@@ -115,7 +115,7 @@ class CloudFormationUtils:
         return response.get('TemplateBody', {})
 
     # Resource Scan API methods
-    def start_resource_scan(self, resource_type: Optional[List] = None) -> str:
+    def start_resource_scan(self, resource_types: Optional[List] = None) -> str:
         """Start a new resource scan and return the scan ID.
 
         Returns:
@@ -123,19 +123,19 @@ class CloudFormationUtils:
         """
         try:
             logger.info('Starting resource scan...')
-            logger.info(f'Received resource_type: {resource_type} (type: {type(resource_type)})')
+            logger.info(f'Received resource_type: {resource_types} (type: {type(resource_types)})')
 
-            if resource_type and len(resource_type) > 0:
-                logger.info(f'Starting resource scan with filters: {resource_type}')
+            if resource_types and len(resource_types) > 0:
+                logger.info(f'Starting resource scan with filters: {resource_types}')
                 response = self.cfn_client.start_resource_scan(
-                    ScanFilters=[{'Types': resource_type}]
+                    ScanFilters=[{'Types': resource_types}]
                 )
             else:
                 response = self.cfn_client.start_resource_scan()
 
             scan_id = response['ResourceScanId']
             if not scan_id:
-                raise ClientError('Resource scan ID not returned by AWS API')
+                raise ServerError('Resource scan ID not returned by AWS API')
 
             self.resource_scan_id = scan_id
             logger.info(f'Resource scan started with ID: {self.resource_scan_id}')


### PR DESCRIPTION


## Summary

### Changes

Added comprehensive resource scanning capabilities to the CloudFormation MCP server, enabling both partial and full AWS account resource scans. This enhancement includes:

- Implementation of `start_resource_scan` tool for initiating resource scans with optional filtering by resource types
- Support for full account scans (all resource types) and targeted scans (specific resource types like S3 buckets, EC2 instances, RDS databases)
- Fixed type annotation issue in `start_resource_scan` method to ensure proper return type handling
- Enhanced error handling and validation for resource scan operations, along with PromptUser Exception handling

### User experience
Users can now:
- Initiate comprehensive scans of their entire AWS account and retrieve the resource scan ID
- Perform targeted scans for specific resource types  or a whole list of them(e.g., only S3 buckets and EC2 instances)
- Get scan IDs for tracking long-running scan operations

Example usage:
- Full account scan: `start_resource_scan(resource_type=[])`
- Targeted scan: `start_resource_scan(resource_type=["AWS::S3::Bucket", "AWS::EC2::Instance", "AWS::RDS::DBInstance"])`

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (N)

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
