### PR TITLE
feat: Added list-resource-scan-resources and list-related-resources i…

### DIFF
--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/impl/tools/__init__.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/impl/tools/__init__.py
@@ -1,0 +1,27 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools package for CFN MCP Server."""
+
+from .resource_scanner_tools import (
+    list_resources_by_filter_impl,
+    list_related_resources_impl,
+    handle_start_resource_scan,
+)
+
+__all__ = [
+    'list_resources_by_filter_impl',
+    'list_related_resources_impl',
+    'handle_start_resource_scan',
+]

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/impl/tools/resource_scanner_tools.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/impl/tools/resource_scanner_tools.py
@@ -1,0 +1,267 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Resource-related tools for the CFN MCP Server."""
+
+from awslabs.cfn_mcp_server.errors import ClientError, PromptUser, handle_aws_api_error
+from awslabs.cfn_mcp_server.stack_analysis.cloudformation_utils import CloudFormationUtils
+from typing import Any, Dict, List, Optional
+
+
+async def handle_start_resource_scan(
+    resource_types: Optional[List[str]] = None,
+    region: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Start a resource scan for specific AWS resource types or the entire account.
+
+    Args:
+        resource_types: List of AWS resource types to scan (e.g., ["AWS::S3::Bucket", "AWS::RDS::DBInstance"])
+                       Provide an empty list [] to scan the entire account
+        region: AWS region to use (e.g., "us-east-1", "us-west-2")
+
+    Returns:
+        Dict containing the scan information:
+        {
+            "scan_id": The unique identifier for the started scan
+        }
+    """
+    # Prompt user for input if no resource type is provided
+    if resource_types is None:
+        common_resource_types = [
+            'AWS::S3::Bucket',
+            'AWS::EC2::Instance',
+            'AWS::RDS::DBInstance',
+            'AWS::Lambda::Function',
+            'AWS::IAM::Role',
+        ]
+
+        raise PromptUser(
+            'Please specify resource types to scan. Options:\n\n'
+            '1. Provide specific resource types)\n'
+            '2. Provide an empty list [] to scan the entire account\n\n'
+            'Common resource types include:\n'
+            + '\n'.join([f'- {rt}' for rt in common_resource_types])
+            + f'\n\nExample usage:\n'
+            f'- Single resource type: ["AWS::S3::Bucket"]\n'
+            f'- Multiple types: {common_resource_types}\n'
+            f'- Entire account: []'
+        )
+
+    try:
+        cfn_utils = CloudFormationUtils(region=region or 'us-east-1')
+    except Exception as e:
+        raise handle_aws_api_error(e)
+
+    try:
+        scan_id = cfn_utils.start_resource_scan(resource_types)
+        return {
+            'scan_id': scan_id,
+        }
+    except Exception as e:
+        raise handle_aws_api_error(e)
+
+
+async def list_resources_by_filter_impl(
+    resource_identifier: Optional[str] = None,
+    resource_type_prefix: Optional[str] = None,
+    tag_key: Optional[str] = None,
+    tag_value: Optional[str] = None,
+    limit: int = 100,
+    next_token: Optional[str] = None,
+    region: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Simple implementation for listing AWS resources with filtering.
+
+    Args:
+        resource_identifier: Filter by specific resource identifier (e.g., physical ID)
+        resource_type_prefix: Filter by resource type prefix (e.g., "AWS::S3::")
+        tag_key: Filter resources by tag key
+        tag_value: Filter resources by tag value (requires tag_key)
+        limit: Maximum number of resources to return (1-100)
+        next_token: AWS pagination token from previous response
+        region: AWS region to use
+
+    Returns:
+        Dict containing filtered resources and pagination info
+    """
+    # Basic validation
+    if limit < 1 or limit > 100:
+        raise ClientError('Limit must be between 1 and 100')
+
+    try:
+        cfn_utils = CloudFormationUtils(region=region or 'us-east-1')
+
+        # Get latest completed scan
+        scans = cfn_utils.list_resource_scans()
+        latest_scan = next((s for s in scans if s.get('Status') == 'COMPLETE'), None)
+        if not scans:
+            raise ClientError('No resource scans found in account. Please start a resource scan.')
+        if not latest_scan:
+            raise ClientError(
+                'No completed resource scans found. Scan could still be in progress or start a resource scan if you none exists.'
+            )
+
+        # Get filtered resources from AWS API
+        if resource_type_prefix or tag_key or tag_value or resource_identifier:
+            result = cfn_utils.list_resource_scan_resources_with_filters(
+                scan_id=latest_scan['ResourceScanId'],
+                resource_identifier=resource_identifier,
+                resource_type_prefix=resource_type_prefix,
+                tag_key=tag_key,
+                tag_value=tag_value,
+                max_results=limit,
+                next_token=next_token,
+            )
+            resources = result['resources']
+        else:
+            # Get all resources if no filters
+            all_resources = cfn_utils.list_resource_scan_resources(latest_scan['ResourceScanId'])
+            resources = all_resources[:limit]
+            # If more than limit, set next_token (has more boolean)
+            result = {'next_token': None if len(all_resources) <= limit else 'has_more'}
+
+        # Format output
+        managed_resources = []
+        unmanaged_resources = []
+
+        for resource in resources:
+            resource_entry = {
+                'identifier': resource.get('ResourceIdentifier', {}),
+                'resource_type': resource.get('ResourceType'),
+            }
+
+            if resource.get('ManagedByStack'):
+                managed_resources.append(resource_entry)
+            else:
+                unmanaged_resources.append(resource_entry)
+
+        return {
+            'managed_resources': managed_resources,
+            'unmanaged_resources': unmanaged_resources,
+            'count': {
+                'managed': len(managed_resources),
+                'unmanaged': len(unmanaged_resources),
+                'total': len(resources),
+            },
+            'pagination': {
+                'limit': limit,
+                'next_token': result.get('next_token'),
+                'has_more': bool(result.get('next_token')),
+            },
+        }
+
+    except Exception as e:
+        raise handle_aws_api_error(e)
+
+
+async def list_related_resources_impl(
+    resources: List[Dict[str, Any]],
+    max_results: int = 100,
+    next_token: Optional[str] = None,
+    region: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Simple implementation for listing AWS resources related to specified resources.
+
+    Args:
+        resources: List of resources to find related resources for, each resource should be a dictionary
+                   with 'resource_type' and 'resource_identifier' keys.
+                   Example: [{'resource_type': 'AWS::S3::Bucket', 'resource_identifier': 'my-bucket-123'}]
+
+        max_results: Maximum number of related resources to return (1-100)
+        next_token: AWS pagination token from previous response
+        region: AWS region to use
+
+    Returns:
+        Dict containing related resources and pagination info
+    """
+    # Basic validation
+    if not resources:
+        raise ClientError('Please provide at least one resource')
+
+    if len(resources) > 100:
+        raise ClientError('Maximum of 100 resources allowed')
+
+    if max_results < 1 or max_results > 100:
+        raise ClientError('max_results must be between 1 and 100')
+
+    try:
+        cfn_utils = CloudFormationUtils(region=region or 'us-east-1')
+
+        # Get latest completed scan
+        scans = cfn_utils.list_resource_scans()
+        latest_scan = next((s for s in scans if s.get('Status') == 'COMPLETE'), None)
+        if not scans:
+            raise ClientError('No resource scans found in account. Please start a resource scan.')
+        if not latest_scan:
+            raise ClientError(
+                'No completed resource scans found. Scan could still be in progress or start a resource scan if you none exists.'
+            )
+
+        # Format resources for API call
+        formatted_resources = []
+        for resource in resources:
+            if not isinstance(resource, Dict):
+                raise ClientError('Each resource must be a dictionary')
+
+            resource_type = resource.get('resource_type')
+            resource_identifier = resource.get('resource_identifier')
+
+            if not resource_type or not resource_identifier:
+                raise ClientError('Each resource must have resource_type and resource_identifier')
+
+            formatted_resources.append(
+                {'ResourceType': resource_type, 'ResourceIdentifier': resource_identifier}
+            )
+
+        # Call AWS API
+        response = cfn_utils.cfn_client.list_resource_scan_related_resources(
+            ResourceScanId=latest_scan['ResourceScanId'],
+            Resources=formatted_resources,
+            MaxResults=max_results,
+            **({'NextToken': next_token} if next_token else {}),
+        )
+
+        related_resources = response.get('RelatedResources', [])
+
+        managed_resources = []
+        unmanaged_resources = []
+
+        for resource in related_resources:
+            resource_entry = {
+                'resource_type': resource.get('ResourceType'),
+                'resource_identifier': resource.get('ResourceIdentifier', {}),
+                'managed_by_stack': resource.get('ManagedByStack', False),
+            }
+
+            if resource.get('ManagedByStack'):
+                managed_resources.append(resource_entry)
+            else:
+                unmanaged_resources.append(resource_entry)
+
+        return {
+            'related_resources': {'managed': managed_resources, 'unmanaged': unmanaged_resources},
+            'count': {
+                'managed': len(managed_resources),
+                'unmanaged': len(unmanaged_resources),
+                'total': len(related_resources),
+            },
+            'pagination': {
+                'max_results': max_results,
+                'next_token': response.get('NextToken'),
+                'has_more': bool(response.get('NextToken')),
+            },
+        }
+
+    except Exception as e:
+        raise handle_aws_api_error(e)

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/impl/tools/resource_scanner_tools.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/impl/tools/resource_scanner_tools.py
@@ -14,7 +14,7 @@
 
 """Resource-related tools for the CFN MCP Server."""
 
-from awslabs.cfn_mcp_server.errors import ClientError, PromptUser, handle_aws_api_error
+from awslabs.cfn_mcp_server.errors import ClientError, handle_aws_api_error
 from awslabs.cfn_mcp_server.stack_analysis.cloudformation_utils import CloudFormationUtils
 from typing import Any, Dict, List, Optional
 
@@ -36,28 +36,6 @@ async def handle_start_resource_scan(
             "scan_id": The unique identifier for the started scan
         }
     """
-    # Prompt user for input if no resource type is provided
-    if resource_types is None:
-        common_resource_types = [
-            'AWS::S3::Bucket',
-            'AWS::EC2::Instance',
-            'AWS::RDS::DBInstance',
-            'AWS::Lambda::Function',
-            'AWS::IAM::Role',
-        ]
-
-        raise PromptUser(
-            'Please specify resource types to scan. Options:\n\n'
-            '1. Provide specific resource types)\n'
-            '2. Provide an empty list [] to scan the entire account\n\n'
-            'Common resource types include:\n'
-            + '\n'.join([f'- {rt}' for rt in common_resource_types])
-            + f'\n\nExample usage:\n'
-            f'- Single resource type: ["AWS::S3::Bucket"]\n'
-            f'- Multiple types: {common_resource_types}\n'
-            f'- Entire account: []'
-        )
-
     try:
         cfn_utils = CloudFormationUtils(region=region or 'us-east-1')
     except Exception as e:
@@ -74,48 +52,56 @@ async def handle_start_resource_scan(
 
 async def list_resources_by_filter_impl(
     resource_identifier: Optional[str] = None,
+    resource_scan_id: Optional[str] = None,
     resource_type_prefix: Optional[str] = None,
     tag_key: Optional[str] = None,
     tag_value: Optional[str] = None,
-    limit: int = 100,
+    limit: Optional[int] = 100,
     next_token: Optional[str] = None,
     region: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Simple implementation for listing AWS resources with filtering.
+    """Simple implementation for listing AWS resources with filtering. If no filters are provided, returns all resources which can exhaust the token limit.
+
+    It is recommended to use filters to limit the number of resources returned.
 
     Args:
         resource_identifier: Filter by specific resource identifier (e.g., physical ID)
+        resource_scan_id: Use a specific resource scan ID instead of the latest completed scan
         resource_type_prefix: Filter by resource type prefix (e.g., "AWS::S3::")
         tag_key: Filter resources by tag key
-        tag_value: Filter resources by tag value (requires tag_key)
-        limit: Maximum number of resources to return (1-100)
+        tag_value: Filter resources by tag value
+        limit: Maximum number of resources to return (1-100) (Optional)
         next_token: AWS pagination token from previous response
         region: AWS region to use
 
     Returns:
         Dict containing filtered resources and pagination info
     """
-    # Basic validation
-    if limit < 1 or limit > 100:
-        raise ClientError('Limit must be between 1 and 100')
-
     try:
         cfn_utils = CloudFormationUtils(region=region or 'us-east-1')
 
-        # Get latest completed scan
-        scans = cfn_utils.list_resource_scans()
-        latest_scan = next((s for s in scans if s.get('Status') == 'COMPLETE'), None)
-        if not scans:
-            raise ClientError('No resource scans found in account. Please start a resource scan.')
-        if not latest_scan:
-            raise ClientError(
-                'No completed resource scans found. Scan could still be in progress or start a resource scan if you none exists.'
-            )
+        # Determine which scan ID to use
+        if not resource_scan_id:
+            # Get latest completed scan
+            scans = cfn_utils.list_resource_scans()
+            if not scans:
+                raise ClientError(
+                    'No resource scans found in account. Please start a resource scan.'
+                )
+            latest_scan = next((s for s in scans if s.get('Status') == 'COMPLETE'), None)
+            if not latest_scan:
+                raise ClientError(
+                    'No completed resource scans found. Scan could still be in progress or start a resource scan if you none exists.'
+                )
+            scan_id = latest_scan['ResourceScanId']
+        else:
+            # Use the provided scan ID
+            scan_id = resource_scan_id
 
         # Get filtered resources from AWS API
         if resource_type_prefix or tag_key or tag_value or resource_identifier:
             result = cfn_utils.list_resource_scan_resources_with_filters(
-                scan_id=latest_scan['ResourceScanId'],
+                scan_id=scan_id,
                 resource_identifier=resource_identifier,
                 resource_type_prefix=resource_type_prefix,
                 tag_key=tag_key,
@@ -124,12 +110,14 @@ async def list_resources_by_filter_impl(
                 next_token=next_token,
             )
             resources = result['resources']
+            next_token_value = result.get('next_token')
         else:
             # Get all resources if no filters
-            all_resources = cfn_utils.list_resource_scan_resources(latest_scan['ResourceScanId'])
-            resources = all_resources[:limit]
-            # If more than limit, set next_token (has more boolean)
-            result = {'next_token': None if len(all_resources) <= limit else 'has_more'}
+            result = cfn_utils.list_resource_scan_resources_with_filters(
+                scan_id=scan_id, next_token=next_token
+            )
+            resources = result['resources']
+            next_token_value = result.get('next_token')
 
         # Format output
         managed_resources = []
@@ -156,8 +144,8 @@ async def list_resources_by_filter_impl(
             },
             'pagination': {
                 'limit': limit,
-                'next_token': result.get('next_token'),
-                'has_more': bool(result.get('next_token')),
+                'next_token': next_token_value,
+                'has_more': bool(next_token_value),
             },
         }
 
@@ -167,6 +155,7 @@ async def list_resources_by_filter_impl(
 
 async def list_related_resources_impl(
     resources: List[Dict[str, Any]],
+    resource_scan_id: Optional[str] = None,
     max_results: int = 100,
     next_token: Optional[str] = None,
     region: Optional[str] = None,
@@ -176,8 +165,8 @@ async def list_related_resources_impl(
     Args:
         resources: List of resources to find related resources for, each resource should be a dictionary
                    with 'resource_type' and 'resource_identifier' keys.
-                   Example: [{'resource_type': 'AWS::S3::Bucket', 'resource_identifier': 'my-bucket-123'}]
-
+                   Example: [{'resource_type': 'AWS::S3::Bucket', 'resource_identifier': BucketName': 'my-bucket-123'}]
+        resource_scan_id: Use a specific resource scan ID instead of the latest completed scan
         max_results: Maximum number of related resources to return (1-100)
         next_token: AWS pagination token from previous response
         region: AWS region to use
@@ -198,15 +187,23 @@ async def list_related_resources_impl(
     try:
         cfn_utils = CloudFormationUtils(region=region or 'us-east-1')
 
-        # Get latest completed scan
-        scans = cfn_utils.list_resource_scans()
-        latest_scan = next((s for s in scans if s.get('Status') == 'COMPLETE'), None)
-        if not scans:
-            raise ClientError('No resource scans found in account. Please start a resource scan.')
-        if not latest_scan:
-            raise ClientError(
-                'No completed resource scans found. Scan could still be in progress or start a resource scan if you none exists.'
-            )
+        # Determine which scan ID to use
+        if not resource_scan_id:
+            # Get latest completed scan
+            scans = cfn_utils.list_resource_scans()
+            if not scans:
+                raise ClientError(
+                    'No resource scans found in account. Please start a resource scan.'
+                )
+            latest_scan = next((s for s in scans if s.get('Status') == 'COMPLETE'), None)
+            if not latest_scan:
+                raise ClientError(
+                    'No completed resource scans found. Scan could still be in progress or start a resource scan if you none exists.'
+                )
+            scan_id = latest_scan['ResourceScanId']
+        else:
+            # Use the provided scan ID
+            scan_id = resource_scan_id
 
         # Format resources for API call
         formatted_resources = []
@@ -226,7 +223,7 @@ async def list_related_resources_impl(
 
         # Call AWS API
         response = cfn_utils.cfn_client.list_resource_scan_related_resources(
-            ResourceScanId=latest_scan['ResourceScanId'],
+            ResourceScanId=scan_id,
             Resources=formatted_resources,
             MaxResults=max_results,
             **({'NextToken': next_token} if next_token else {}),
@@ -240,7 +237,7 @@ async def list_related_resources_impl(
         for resource in related_resources:
             resource_entry = {
                 'resource_type': resource.get('ResourceType'),
-                'resource_identifier': resource.get('ResourceIdentifier', {}),
+                'identifier': resource.get('ResourceIdentifier', {}),
                 'managed_by_stack': resource.get('ManagedByStack', False),
             }
 

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/impl/tools/resource_scanner_tools.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/impl/tools/resource_scanner_tools.py
@@ -60,7 +60,7 @@ async def list_resources_by_filter_impl(
     next_token: Optional[str] = None,
     region: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Simple implementation for listing AWS resources with filtering. If no filters are provided, returns all resources which can exhaust the token limit.
+    """Simple implementation for listing AWS resources with filtering. If no filters are provided, returns a page containing upto a 100 resources.
 
     It is recommended to use filters to limit the number of resources returned.
 
@@ -165,7 +165,7 @@ async def list_related_resources_impl(
     Args:
         resources: List of resources to find related resources for, each resource should be a dictionary
                    with 'resource_type' and 'resource_identifier' keys.
-                   Example: [{'resource_type': 'AWS::S3::Bucket', 'resource_identifier': BucketName': 'my-bucket-123'}]
+                   Example: [{'resource_type': 'AWS::S3::Bucket', 'resource_identifier': { BucketName': 'my-bucket-123'}]
         resource_scan_id: Use a specific resource scan ID instead of the latest completed scan
         max_results: Maximum number of related resources to return (1-100)
         next_token: AWS pagination token from previous response
@@ -226,9 +226,7 @@ async def list_related_resources_impl(
             ResourceScanId=scan_id,
             Resources=formatted_resources,
             MaxResults=max_results,
-            **({'NextToken': next_token} if next_token else {}),
         )
-
         related_resources = response.get('RelatedResources', [])
 
         managed_resources = []

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
@@ -19,10 +19,14 @@ import json
 from awslabs.cfn_mcp_server.aws_client import get_aws_client
 from awslabs.cfn_mcp_server.cloud_control_utils import progress_event, validate_patch
 from awslabs.cfn_mcp_server.context import Context
-from awslabs.cfn_mcp_server.errors import ClientError, PromptUser, handle_aws_api_error
+from awslabs.cfn_mcp_server.errors import ClientError, handle_aws_api_error
 from awslabs.cfn_mcp_server.iac_generator import create_template as create_template_impl
+from awslabs.cfn_mcp_server.impl.tools import (
+    handle_start_resource_scan,
+    list_related_resources_impl,
+    list_resources_by_filter_impl,
+)
 from awslabs.cfn_mcp_server.schema_manager import schema_manager
-from awslabs.cfn_mcp_server.stack_analysis.cloudformation_utils import CloudFormationUtils
 from awslabs.cfn_mcp_server.stack_analysis.stack_analyzer import StackAnalyzer
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
@@ -423,6 +427,107 @@ async def create_template(
 
 
 @mcp.tool()
+async def list_resources_by_filter(
+    resource_identifier: str | None = Field(
+        default=None,
+        description='Filter by specific resource identifier (e.g., "my-bucket-name")',
+    ),
+    resource_type_prefix: str | None = Field(
+        default=None,
+        description='Filter by resource type prefix (e.g., "AWS::S3::" to get all S3 resources)',
+    ),
+    tag_key: str | None = Field(default=None, description='Filter resources by tag key'),
+    tag_value: str | None = Field(
+        default=None,
+        description='Filter resources by tag value (requires tag_key to be specified)',
+    ),
+    limit: int = Field(
+        default=100,
+        description='Maximum number of resources to return (default: 100, max: 100 due to AWS API limits)',
+    ),
+    next_token: str | None = Field(
+        default=None, description='Pagination token from previous response to get next page'
+    ),
+    region: str | None = Field(
+        description='The AWS region that the operation should be performed in', default=None
+    ),
+) -> dict:
+    """List AWS resources with filtering support.
+
+    To preserve tokens usage, this tool allows you to filter resources by type resourcetypeprefix,
+    tag key, and tag value. It returns a paginated list of resource identifiers. It is recommended
+    to use the filtering parameters to reduce the number of resources returned,
+
+    This tool uses AWS CloudFormation's resource scan API with server-side filtering.
+    All parameters are optional except for the ResourceScanId (automatically handled).
+
+    Parameters:
+        resource_type_prefix: Filter by resource type prefix (optional)
+        tag_key: Filter resources by tag key (optional)
+        tag_value: Filter resources by tag value (optional, requires tag_key)
+        limit: Maximum number of resources to return (1-100, AWS API limit)
+        next_token: AWS pagination token from previous response (optional)
+        region: AWS region to use (optional)
+
+    Returns:
+        Resource identifiers with filtering applied at the AWS API level and pagination metadata
+    """
+    return await list_resources_by_filter_impl(
+        resource_identifier=resource_identifier,
+        resource_type_prefix=resource_type_prefix,
+        tag_key=tag_key,
+        tag_value=tag_value,
+        limit=limit,
+        next_token=next_token,
+        region=region,
+    )
+
+
+@mcp.tool()
+async def list_related_resources(
+    resources: list = Field(
+        description='List of resources to find related resources for. Each resource should have resource_type and resource_identifier keys.'
+    ),
+    max_results: int = Field(
+        default=100,
+        description='Maximum number of related resources to return (default: 100, max: 100 due to AWS API limits)',
+    ),
+    next_token: str | None = Field(
+        default=None, description='Pagination token from previous response to get next page'
+    ),
+    region: str | None = Field(
+        description='The AWS region that the operation should be performed in', default=None
+    ),
+) -> dict:
+    """List AWS resources related to the specified resources.
+
+    This tool uses AWS CloudFormation's list_resource_scan_related_resources API
+    to find resources that are related to the specified input resources.
+
+    Parameters:
+        resources: List of resources to find related resources for. Each resource should have
+                  'resource_type' and 'resource_identifier' keys. Maximum 100 resources.
+        max_results: Maximum number of related resources to return (1-100, AWS API limit)
+        next_token: AWS pagination token from previous response (optional)
+        region: AWS region to use (optional)
+
+    Returns:
+        Related resources grouped by managed/unmanaged status with pagination metadata
+
+    Example:
+        resources = [
+            {
+                "resource_type": "AWS::S3::Bucket",
+                "resource_identifier": {"BucketName": "my-bucket"}
+            }
+        ]
+    """
+    return await list_related_resources_impl(
+        resources=resources, max_results=max_results, next_token=next_token, region=region
+    )
+
+
+@mcp.tool()
 async def start_resource_scan(
     resource_types: list | None = Field(
         default=None,
@@ -445,40 +550,10 @@ async def start_resource_scan(
             "scan_id": The unique identifier for the started scan
         }
     """
-    # Prompt user for input if no resource type is provided
-    if resource_types is None:
-        common_resource_types = [
-            'AWS::S3::Bucket',
-            'AWS::EC2::Instance',
-            'AWS::RDS::DBInstance',
-            'AWS::Lambda::Function',
-            'AWS::IAM::Role',
-        ]
-
-        raise PromptUser(
-            'Please specify resource types to scan. Options:\n\n'
-            '1. Provide specific resource types)\n'
-            '2. Provide an empty list [] to scan the entire account\n\n'
-            'Common resource types include:\n'
-            + '\n'.join([f'- {rt}' for rt in common_resource_types])
-            + f'\n\nExample usage:\n'
-            f'- Single resource type: ["AWS::S3::Bucket"]\n'
-            f'- Multiple types: {common_resource_types}\n'
-            f'- Entire account: []'
-        )
-
-    try:
-        cfn_utils = CloudFormationUtils(region=region or 'us-east-1')
-    except Exception as e:
-        raise handle_aws_api_error(e)
-
-    try:
-        scan_id = cfn_utils.start_resource_scan(resource_types)
-        return {
-            'scan_id': scan_id,
-        }
-    except Exception as e:
-        raise handle_aws_api_error(e)
+    return await handle_start_resource_scan(
+        resource_types=resource_types,
+        region=region,
+    )
 
 
 @mcp.tool()

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
@@ -462,6 +462,7 @@ async def list_resources_by_filter(
     All parameters are optional except for the ResourceScanId (automatically handled).
 
     Parameters:
+        resource_identifier: Filter by specific resource identifier (optional)
         resource_type_prefix: Filter by resource type prefix (optional)
         tag_key: Filter resources by tag key (optional)
         tag_value: Filter resources by tag value (optional, requires tag_key)

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
@@ -463,7 +463,6 @@ async def list_resources_by_filter(
     to use the filtering parameters to reduce the number of resources returned,
 
     This tool uses AWS CloudFormation's resource scan API with server-side filtering.
-    All parameters are optional except for the ResourceScanId (automatically handled).
 
     Parameters:
         resource_identifier: Filter by specific resource identifier (optional)

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/server.py
@@ -432,6 +432,10 @@ async def list_resources_by_filter(
         default=None,
         description='Filter by specific resource identifier (e.g., "my-bucket-name")',
     ),
+    resource_scan_id: str | None = Field(
+        default=None,
+        description='Resource scan ID to use for filtering resources. If not provided, the latest completed scan will be used.',
+    ),
     resource_type_prefix: str | None = Field(
         default=None,
         description='Filter by resource type prefix (e.g., "AWS::S3::" to get all S3 resources)',
@@ -443,7 +447,7 @@ async def list_resources_by_filter(
     ),
     limit: int = Field(
         default=100,
-        description='Maximum number of resources to return (default: 100, max: 100 due to AWS API limits)',
+        description='Maximum number of resources to return',
     ),
     next_token: str | None = Field(
         default=None, description='Pagination token from previous response to get next page'
@@ -463,6 +467,8 @@ async def list_resources_by_filter(
 
     Parameters:
         resource_identifier: Filter by specific resource identifier (optional)
+        resource_scan_id: Resource scan ID to use for filtering resources. (optional)
+                           If not provided, the latest completed scan will be used even if it's partial or full scan.
         resource_type_prefix: Filter by resource type prefix (optional)
         tag_key: Filter resources by tag key (optional)
         tag_value: Filter resources by tag value (optional, requires tag_key)
@@ -475,6 +481,7 @@ async def list_resources_by_filter(
     """
     return await list_resources_by_filter_impl(
         resource_identifier=resource_identifier,
+        resource_scan_id=resource_scan_id,
         resource_type_prefix=resource_type_prefix,
         tag_key=tag_key,
         tag_value=tag_value,
@@ -489,6 +496,10 @@ async def list_related_resources(
     resources: list = Field(
         description='List of resources to find related resources for. Each resource should have resource_type and resource_identifier keys.'
     ),
+    resource_scan_id: str | None = Field(
+        default=None,
+        description='Resource scan ID to use for finding related resources. If not provided, the latest completed scan will be used.',
+    ),
     max_results: int = Field(
         default=100,
         description='Maximum number of related resources to return (default: 100, max: 100 due to AWS API limits)',
@@ -500,14 +511,18 @@ async def list_related_resources(
         description='The AWS region that the operation should be performed in', default=None
     ),
 ) -> dict:
-    """List AWS resources related to the specified resources.
+    """List AWS resources related to the specified list of resources or resource.
 
     This tool uses AWS CloudFormation's list_resource_scan_related_resources API
     to find resources that are related to the specified input resources.
 
+    Note: Call with one resource at a time if you want explicitly related resources
+
     Parameters:
         resources: List of resources to find related resources for. Each resource should have
                   'resource_type' and 'resource_identifier' keys. Maximum 100 resources.
+        resource_scan_id: Resource scan ID to use for finding related resources.
+                         If not provided, the latest completed scan will be used even if it's partial or full scan.
         max_results: Maximum number of related resources to return (1-100, AWS API limit)
         next_token: AWS pagination token from previous response (optional)
         region: AWS region to use (optional)
@@ -524,7 +539,11 @@ async def list_related_resources(
         ]
     """
     return await list_related_resources_impl(
-        resources=resources, max_results=max_results, next_token=next_token, region=region
+        resources=resources,
+        resource_scan_id=resource_scan_id,
+        max_results=max_results,
+        next_token=next_token,
+        region=region,
     )
 
 
@@ -631,6 +650,7 @@ async def analyze_stack(
             'outputs': stack_analysis.get('outputs', []),
             'parameters': stack_analysis.get('parameters', []),
             # Stack resource matching results
+            'prompt': f'Analyze the CloudFormation stack "{stack_name}" and its resources Offer insights on the stack resources, related resources, and best practices.',
             'stack_name': resources_data.get('stack_name'),
             'resource_scan_id': resources_data.get('resource_scan_id'),
             'matched_resources': resources_data.get('matched_resources', []),

--- a/src/cfn-mcp-server/awslabs/cfn_mcp_server/stack_analysis/cloudformation_utils.py
+++ b/src/cfn-mcp-server/awslabs/cfn_mcp_server/stack_analysis/cloudformation_utils.py
@@ -24,11 +24,11 @@ logger = logging.getLogger(__name__)
 class CloudFormationUtils:
     """Utility class for CloudFormation API operations."""
 
-    def __init__(self, region: Optional[str] = None):
+    def __init__(self, region: Optional[str] = None, resource_scan_id: Optional[str] = None):
         """Initialize the CloudFormationUtils with the specified AWS region and store the resource scan ID."""
         self.region = region
         self._cfn_client = None
-        self.resource_scan_id: Optional[str] = None
+        self.resource_scan_id = resource_scan_id
 
     @property
     def cfn_client(self):

--- a/src/cfn-mcp-server/pyproject.toml
+++ b/src/cfn-mcp-server/pyproject.toml
@@ -19,6 +19,8 @@ authors = [
     {name = "Karam Singh", email="karam.singh.vir@gmail.com"},
     {name = "Brian Terry", email="brianter@amazon.com"},
     {name = "Shardul Vaidya", email="cam.v737@gmail.com"},
+    {name = "Akila Tennakoon", email="tennakoo@amazon.com"},
+    {name = "Tenzing Sherpa", email="tenzingsherpa@princeton.edu"}
 ]
 classifiers = [
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary
Refactored the project directory structure as to not have verbose code in server.py - Inspired by Terraform's server.py and Akila's tools implementation. Upcoming PR will also refactor for analyze_stack() MCP tool

Enhanced the CloudFormation MCP server with critical resource discovery and relationship analysis capabilities. This update adds resource filtering functionality to help users efficiently discover AWS resources while respecting API rate limits and token usage constraints.

Added Critical List-resource-scan-resources and List-resource-scan-related-resources functionality to our MCP package. The implementation makes it so list-resource call leverages the use of supported API filters such as (resourcetypeprefix, resourceIdentifier, tag value and tag key ) as a consideration for the user's token limits. It is up-to the user to specify these filters by simply stating "run the list resource with {filter} " 

Also added a list-related-resource MCP tool that expects a List of Dictionary "resources" which are specified in the parameters info on the tool and returns a list of related resources classified by managed and unmanaged. 

__Key Additions:__

- __`list_resources_by_filter`__: Comprehensive resource filtering tool supporting AWS CloudFormation resource scan API filters (resource type prefix, resource identifier, tag key/value)
- __`list_related_resources`__: relationship discovery tool that identifies connected AWS resources, both managed and unmanaged by CloudFormation


The implementation leverages AWS CloudFormation's resource scan API with server-side filtering to minimize token usage and API calls. 

## Changes

### Core Functionality Added

- __Resource Filtering Tool (`list_resources_by_filter`)__:

  - Server-side filtering using AWS CloudFormation resource scan API
  - Support for resource type prefix filtering (e.g., "AWS::S3::" for all S3 resources)
  - Resource identifier filtering by physical resource ID
  - Tag-based filtering (tag key and tag value)
  - Pagination support with configurable limits (1-100 resources)
  - Categorizes results into managed vs unmanaged resources

- __Resource Relationship Discovery (`list_related_resources`)__:

  
  - Maps resource  relationships
  - Identifies both CloudFormation-managed and unmanaged related resources
  - Supports up to 100 input resources per call
  - Returns structured results with resource type, identifier, and management status

## Testing

- Functional Testing__: Tested with real AWS resources across multiple services (S3, CloudFront, Lambda, KMS, IAM, SQS)
- Parameter Validation__: Verified all parameter types work correctly without validation errors
- Error Handling__: Confirmed proper error handling for expired tokens and invalid inputs
- Response Structure__: Validated managed/unmanaged resource categorization
- Pagination__: Tested pagination with various limits and token handling
- Edge Cases__: Tested with empty results, maximum resource limits, and various AWS resource types

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x ] I have performed a self-review of this change
* [ x] Changes have been tested
* [ x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
